### PR TITLE
fix: tsc default import dep error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "graphql-middleware-error-handler",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^16.11.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-middleware-error-handler",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Generic GraphQL middleware to capture errors",
   "main": "dist/index.js",
   "scripts": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,8 @@
     "lib": ["esnext"],
     "noUnusedLocals": true,
     "noImplicitAny": true,
-    "outDir": "dist"
+    "outDir": "dist",
+    "esModuleInterop": true
   },
   "include": [
     "src/**/*"


### PR DESCRIPTION
While checking why the new version(1.0.0) was not working as expected, i found the package was published without the `dist` folder.
To create the `dist` folder, the `npm run prepublish` command needs to be run. This executes `tsc -d` which failed with the following error:

```
> graphql-middleware-error-handler@1.0.0 build
> tsc -d

node_modules/@graphql-tools/delegate/types.d.ts:2:8 - error TS1259: Module '"/Users/eelcokoelewijn/Projects/_work/graphql-middleware-error-handler/node_modules/dataloader/index"' can only be default-imported using the 'esModuleInterop' flag

2 import DataLoader from 'dataloader';
         ~~~~~~~~~~

  node_modules/dataloader/index.d.ts:121:1
    121 export = DataLoader;
        ~~~~~~~~~~~~~~~~~~~~
    This module is declared with using 'export =', and can only be used with a default import when using the 'esModuleInterop' flag.

Found 1 error.

```

This can be fixed by enabling `esModuleInterop` in the `tsconfig.json`, not sure if this is bad-practice, you can read more about `esModuleInterop` [here](https://www.typescriptlang.org/tsconfig#esModuleInterop).